### PR TITLE
Python3 Update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=0.10.1
 Jinja2>=2.7.3
-MarkupSafe>=0.23
+MarkupSafe>=1.0
 Werkzeug>=0.10.4
 itsdangerous>=0.24
 nose>=1.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wsgiref==0.1.2; python_version < '3.0'
 Flask>=0.10.1
 Jinja2>=2.7.3
 MarkupSafe>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-Flask==0.10.1
-Jinja2==2.7.3
-MarkupSafe==0.23
-Werkzeug==0.10.4
-itsdangerous==0.24
-nose==1.3.6
-pymongo==2.8
-wsgiref==0.1.2
+Flask>=0.10.1
+Jinja2>=2.7.3
+MarkupSafe>=0.23
+Werkzeug>=0.10.4
+itsdangerous>=0.24
+nose>=1.3.6
+pymongo>=2.8


### PR DESCRIPTION
Minor update for python3 compat.  The only real major change was upping the `MarkupSafe` version to 1.0.  

Should still be compatible with python2.